### PR TITLE
b::Vector

### DIFF
--- a/src/expmv_fun.jl
+++ b/src/expmv_fun.jl
@@ -25,7 +25,7 @@ a parameter (or a `StepRangeLen` object representing a range of values).
 * `full_term = false`: set to `true` to evaluate the full Taylor expansion instead
         of truncating when reaching the required precision
 """
-function expmv(t::Number, A::SparseMatrixCSC, b::Vector; M = nothing,
+function expmv(t::Number, A::SparseMatrixCSC, b::VecOrMat; M = nothing,
                 precision = "double", shift = false, full_term = false)
     n = size(A, 1)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,12 +20,21 @@ using SparseArrays
             @testset "Against expm" begin
                 @test norm(x-exp(Matrix(rt*r))*rv,2) ≈ 0.0 atol=1.0e-9
             end
+
             # Test the StepRangeLen version against the normal version
             @testset "Timespan $nt timesteps" for nt in [5 11 51]
                 t = range(0, stop=rt, length=nt)
                 x = expmv(t,r,rv)
                 y = hcat([expmv(ti,r,rv) for ti in t]...)
                 @test x ≈ y atol=1.0e-10
+            end
+
+            @testset "Second dim: $d2" for d2 in 2:4
+                rv = randn(d,d2)+1im*randn(d,d2)
+                rv = rv*diagm(0 => [1.0/norm(rv[:,j],2) for j in 1:d2])
+
+                x = expmv(rt,r,rv)
+                @test norm(x-exp(Matrix(rt*r))*rv,2) ≈ 0.0 atol=1.0e-9
             end
         end
     end


### PR DESCRIPTION
I am thinking that `b` should not be restricted to vector. Mentioned in Al-Mohy's paper, the algorithm is suitable for vector b of dimension n by n_0 with n_0 << n. Is there any reason for `b::Vector`?

I wanted to open an issue first, but the issue tab is not enabled in this repo :(