### PR TITLE
Add support to LinearMaps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
 
 [targets]
-test = ["Test"]
+test = ["Test", "LinearMaps"]

--- a/src/expmv_fun.jl
+++ b/src/expmv_fun.jl
@@ -21,7 +21,7 @@ a parameter (or a `StepRangeLen` object representing a range of values).
 * `full_term = false`: set to `true` to evaluate the full Taylor expansion instead
         of truncating when reaching the required precision
 """
-function expmv(t::Number, A::SparseMatrixCSC, b::VecOrMat; M = nothing,
+function expmv(t::Number, A, b::VecOrMat; M = nothing,
                 precision = "double", shift = false, full_term = false)
     n = size(A, 1)
 

--- a/src/expmv_fun.jl
+++ b/src/expmv_fun.jl
@@ -25,6 +25,12 @@ function expmv(t::Number, A, b::VecOrMat; M = nothing,
                 precision = "double", shift = false, full_term = false)
     n = size(A, 1)
 
+    if shift == true && !hasmethod(tr, typeof(A))
+        shift = false
+        @warn "Shift set to false as $(typeof(A)) doesn't support tr"
+    end
+
+    mu = 0.
     if shift
         mu = tr(A)/n
         A = A - mu*I

--- a/src/expmv_tspan.jl
+++ b/src/expmv_tspan.jl
@@ -1,15 +1,22 @@
 using LinearAlgebra
 using SparseArrays
 
-function expmv(t::StepRangeLen, A::SparseMatrixCSC, b::Vector;
-                M = nothing, precision = "double", shift = true)
+function expmv(t::StepRangeLen, A, b::Vector;
+                M = nothing, precision = "double", shift = false)
 
     t0 = Float64(t.ref)
     tmax = Float64(t.ref + (t.len - 1.) * t.step)
     q = t.len - 1
     n = size(A, 1)
 
-    force_estm = false; temp = (tmax -t0)*norm(A, 1);
+    if shift == true && !hasmethod(tr, typeof(A))
+        shift = false
+        @warn "Shift set to false as $(typeof(A)) doesn't support tr"
+    end
+
+    force_estm = !hasmethod(opnorm, Tuple{typeof(A), typeof(1)})
+    temp = (tmax - t0) * normAm(A, 1);
+
     if (precision == "single" || precision == "half" && temp > 85.496) || ( precision == "double" && temp > 63.152)
        force_estm = true;
     end

--- a/src/norm1est.jl
+++ b/src/norm1est.jl
@@ -29,13 +29,11 @@
 
 function A_pow_n_B!(res, x, n::Integer, y)
     tmp = similar(y)
-    #tmp2 = similar(y)
     mul!(res, x, y)
     for i in 1:n-1
         mul!(tmp, x, res)
         copyto!(res, tmp)
     end
-    #copyto!(res, tmp)
 end
 
 function At_pow_n_B!(res, x , n::Integer, y)

--- a/src/norm1est.jl
+++ b/src/norm1est.jl
@@ -27,20 +27,21 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-function A_pow_n_B!(res, x, n::Integer, y)
-    tmp = similar(y)
-    mul!(res, x, y)
+
+function A_pow_n_B!(res, A, n::Integer, v)
+    tmp = similar(v)
+    mul!(res, A, v)
     for i in 1:n-1
-        mul!(tmp, x, res)
+        mul!(tmp, A, res)
         copyto!(res, tmp)
     end
 end
 
-function At_pow_n_B!(res, x , n::Integer, y)
-    tmp = similar(y)
-    mul!(res, adjoint(x), y)
+function At_pow_n_B!(res, A, n::Integer, v)
+    tmp = similar(v)
+    mul!(res, adjoint(A), v)
     for i in 1:n-1
-        mul!(tmp, adjoint(x), res)
+        mul!(tmp, adjoint(A), res)
         copyto!(res, tmp)
     end
 end

--- a/src/norm1est.jl
+++ b/src/norm1est.jl
@@ -46,7 +46,7 @@ function At_pow_n_B!(res, A, n::Integer, v)
     end
 end
 
-function norm1est(m::Integer, A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A)))) where T
+function norm1est(m::Integer, A, t::Integer = min(2,maximum(size(A))))
     # Effectively implements Algorithm 2.4 of Higham, Tisseur, SIAM J. Mat. Anal. Appl. 21, 1185 (2000)
     # The first argument is the power to which A is raised.
 
@@ -66,8 +66,8 @@ function norm1est(m::Integer, A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(
     ind = Array{Integer}(undef, n)
     ind_hist = Array{Integer}(undef, maxiter * t)
 
-    Ti = typeof(float(zero(T)))
-
+    #Ti = typeof(float(zero(T)))
+    Ti = eltype(A)
     S = zeros(Ti, n, t)
 
     function _rand_pm1!(v)
@@ -152,7 +152,7 @@ function norm1est(m::Integer, A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(
         # TODO: Check if every column of S is parallel to a column of S_old:
         #       you should break in this case
 
-        if T <: Real
+        if Ti <: Real
             # Check wether cols of S are parallel to cols of S or S_old
             for j = 1:t
                 while true

--- a/src/normAm.jl
+++ b/src/normAm.jl
@@ -14,6 +14,18 @@ function normAm(A,m)
     t = 2; # Number of columns used by NORMEST1.
 
     n = size(A, 1);
-
-    return norm1est(m,A,t)
+    if hasmethod(opnorm, Tuple{typeof(A), typeof(1)})
+        if eltype(A) <: Real
+            if sum(A .< 0) == 0 # for positive matrices only
+                e = ones(n,1)
+                f = similar(e)
+                for j=1:m
+                    mul!(f, A, e)
+                    copyto!(e, f)
+                end
+                return norm(e, Inf)
+            end
+        end
+    end
+    return norm1est(m, A, t)
 end

--- a/src/normAm.jl
+++ b/src/normAm.jl
@@ -14,19 +14,6 @@ function normAm(A,m)
     t = 2; # Number of columns used by NORMEST1.
 
     n = size(A, 1);
-    if eltype(A) <: Real
-        if sum(A.nzval .< 0) == 0 # for positive matrices only
-            e = ones(n,1)
-            f = similar(e)
-            for j=1:m
-                mul!(f, A, e)
-                copyto!(e, f)
-            end
-            return norm(e, Inf)
-        else
-            return norm1est(m, A, t)
-        end
-    else
-        return norm1est(m,A,t)
-    end
+
+    return norm1est(m,A,t)
 end

--- a/src/select_taylor_degree.jl
+++ b/src/select_taylor_degree.jl
@@ -82,6 +82,7 @@ function select_taylor_degree(A,
     end
 
     if !force_estm
+        @assert hasmethod(opnorm, Tuple{typeof(A), typeof(1)}) "opnorm not defined for $typeof(A)"
         normA = opnorm(A,1)
     end
 

--- a/src/select_taylor_degree.jl
+++ b/src/select_taylor_degree.jl
@@ -46,7 +46,7 @@ function select_taylor_degree(A,
                               precision = "double",
                               shift = false,
                               # bal,
-                              force_estm = false)
+                              force_estm = true)
 
     #SELECT_TAYLOR_DEGREE   Select degree of Taylor approximation.
     #   [M,MV,alpha,unA] = SELECT_TAYLOR_DEGREE(A,m_max,p_max) forms a matrix M

--- a/src/select_taylor_degree.jl
+++ b/src/select_taylor_degree.jl
@@ -76,7 +76,7 @@ function select_taylor_degree(A,
           theta_half
       end
 
-    if shift
+    if shift && hasmethod(tr, typeof(A))
         mu = tr(A)/n
         A -= mu * I
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,11 +2,13 @@ using ExpmV
 using Test
 using LinearAlgebra
 using SparseArrays
+using LinearMaps
+
 
 @testset "Real matrices" begin
     @testset "Positive: $positive"  for positive in [true, false]
-        @testset "Size: $d" for d in 10:20:70
-            for i = 1:10
+        @testset "Size: $d" for d in [10, 100]
+            for i = 1:10 # Just repeat it a few times
                 r = sprandn(d, d, .1)
 
                 if positive
@@ -14,14 +16,12 @@ using SparseArrays
                 end
 
                 rv = randn(d)
-                rv = rv / norm(rv,2)
+                rv ./= norm(rv, 2)
 
                 rt = randn()
 
-                x = expmv(rt,r,rv)
-
                 @testset "Against expm" begin
-                    @test x ≈ exp(Matrix(rt*r))*rv
+                    @test expmv(rt,r,rv) ≈ exp(Matrix(rt*r))*rv
                 end
 
                 # Test the StepRangeLen version against the normal version
@@ -32,9 +32,10 @@ using SparseArrays
                     @test x ≈ y
                 end
 
+                # Test that it works with matrix instead of vectors
                 @testset "Second dim: $d2" for d2 in 2:4
-                    rv = randn(d,d2)+1im*randn(d,d2)
-                    rv = rv*diagm(0 => [1.0/norm(rv[:,j],2) for j in 1:d2])
+                    rv = randn(d, d2)
+                    rv = rv * diagm(0 => [1.0/norm(rv[:,j],2) for j in 1:d2])
 
                     x = expmv(rt,r,rv)
                     @test x ≈ exp(Matrix(rt*r))*rv
@@ -46,15 +47,15 @@ end
 
 @testset "Complex matrices" begin
     @testset "Hermitian: $herm"  for herm in [true, false]
-        @testset "Size: $d" for d in 10:20:70
+        @testset "Size: $d" for d in [10, 100]
             for i = 1:10
                 r = sprandn(d,d,.1)+1im*sprandn(d,d,.1)
                 if herm
                     r = (r-r')/2
                 end
 
-                rv = randn(d)+1im*randn(d)
-                rv = rv / norm(rv,2)
+                rv = randn(Complex{Float64}, d)
+                rv ./= norm(rv, 2)
 
                 rt = randn()
 
@@ -72,8 +73,8 @@ end
                 end
 
                 @testset "Second dim: $d2" for d2 in 2:4
-                    rv = randn(d,d2)+1im*randn(d,d2)
-                    rv = rv*diagm(0 => [1.0/norm(rv[:,j],2) for j in 1:d2])
+                    rv = randn(Complex{Float64}, d, d2)
+                    rv = rv * diagm(0 => [1.0/norm(rv[:,j],2) for j in 1:d2])
 
                     x = expmv(rt,r,rv)
                     @test x ≈ exp(Matrix(rt*r))*rv
@@ -81,4 +82,20 @@ end
             end
         end
     end
+end
+
+@testset "Linear Operator" begin
+    d = 100
+    A = sprandn(d,d,.1) + 1im * sprandn(d,d,.1)
+    L = LinearMap(A)
+
+    rv = randn(Complex{Float64}, d)
+    rv ./= norm(rv, 2)
+
+    rt = randn()
+
+    @test expmv(rt, L, rv) ≈ expmv(rt, A, rv)
+
+    t = range(0, stop=rt, length=20)
+    @test expmv(t,L,rv) ≈ expmv(t, A, rv)
 end


### PR DESCRIPTION
Since the algorithm is almost entirely based on matrix-vector multiplication, there's no need to require that `A` is a `Matrix`. Apart from the shift feature, the algorithm works with any linear operator as those of [LinearMaps.jl](https://github.com/Jutho/LinearMaps.jl). This PR adds this feature and tests.

See [this issue](https://github.com/marcusps/ExpmV.jl/issues/12) from the original repository of ExpmV.jl